### PR TITLE
Using valid aes key for encryption for local - its a dummy key

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -100,7 +100,7 @@ mongodb {
   uri = "mongodb://localhost:27017/save-your-national-insurance-number"
   timeToLiveInSeconds = 900
   encryption {
-    key = "DUMMY_KEY"
+    key = "z4rWoRLf7a1OHTXLutSDJjhrUzZTBE3b" # random key only to be used locally as specific format is required for encryption
   }
 }
 


### PR DESCRIPTION
DUMMY_KEY isnt a valid aes string so I had to generate a dummy aes string instead - this is only for local